### PR TITLE
Fix intra-line height on windows

### DIFF
--- a/sources/Inconsolata.glyphs
+++ b/sources/Inconsolata.glyphs
@@ -344,11 +344,11 @@ value = 0;
 },
 {
 name = winAscent;
-value = 1004;
+value = 859;
 },
 {
 name = winDescent;
-value = 454;
+value = 190;
 },
 {
 name = hheaAscender;
@@ -431,11 +431,11 @@ value = 0;
 },
 {
 name = winDescent;
-value = 454;
+value = 189;
 },
 {
 name = winAscent;
-value = 1004;
+value = 859;
 }
 );
 descender = -167;


### PR DESCRIPTION
(See closed issue #9)

_Note: unfortunately, I know next to nothing about fonts. If I even knew that I knew nothing, that'd be something, but I don't_ 😄 

I finally got around to trying to figure out what was wrong, and I come up with a fix;  I think I've applied it correctly to the source here, but you probably need to rebuild the TTFs etc still. And I didn't update the version or anything, I thought I'd leave that to you.

I used FontEdit to open the TTF file and found that the ancient Inconsolata I had had a different value for two fields, and correcting those, fixed my problem.

In the `.sfd` file that I created, there are two fields that I changed:

in `Inconsolata-bold` and `ligconsolata-bold`I changed:
``` shell
OS2WinAscent: 859     # was 1004
OSWinDescent: 189     # was 454
```

in `Inconsolata-Regular` and `ligconsolata-Regular` I changed:
``` shell
OS2WinAscent: 859     # was 1004
OSWinDescent: 190     # was 454
```

_I don't know why bold was `189` vs `190` for the `OS2WinDescent` -- I just copied the values out of the original v1 version of Inconsolata and Inconsolata-Bold_

I then cloned this repo, and found the same values, and took a shot at altering them, and voila ... here's the PR to fix it.

As I stated, I know literally nothing about fonts, or how it works, but using FontForge and regenerating the fonts with this makes the font render correctly on Windows again.

I hope this can get merged and I can go back to using 'stock' versions of the fonts :D
